### PR TITLE
Validation

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -642,11 +642,14 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		);
 
 		$schema['properties']['type'] = array(
-			'description' => __( 'Type of menu item' ),
+			'description' => __( 'The family of objects originally represented, such as "post_type" or "taxonomy".' ),
 			'type'        => 'string',
 			'enum'        => array( 'taxonomy', 'post_type', 'post_type_archive', 'custom' ),
-			'default'     => 'custom',
 			'context'     => array( 'view', 'edit', 'embed' ),
+			'default'     => 'custom',
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_key',
+			),
 		);
 
 		$schema['properties']['status'] = array(
@@ -655,14 +658,6 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'enum'        => array_keys( get_post_stati( array( 'internal' => false ) ) ),
 			'default'     => 'publish',
 			'context'     => array( 'view', 'edit', 'embed' ),
-		);
-
-		$schema['properties']['link'] = array(
-			'description' => __( 'URL to the object.' ),
-			'type'        => 'string',
-			'format'      => 'uri',
-			'context'     => array( 'view', 'edit', 'embed' ),
-			'readonly'    => true,
 		);
 
 		$schema['properties']['parent'] = array(
@@ -674,24 +669,35 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		);
 
 		$schema['properties']['attr_title'] = array(
-			'description' => __( 'The title attribute of the link element for this menu item .' ),
-			'context'     => array( 'view', 'edit', 'embed' ),
+			'description' => __( 'Text for the title attribute of the link element for this menu item.' ),
 			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 
 		$schema['properties']['classes'] = array(
-			'description' => __( 'The array of class attribute values for the link element of this menu item .' ),
-			'context'     => array( 'view', 'edit', 'embed' ),
+			'description' => __( 'Class names for the link element of this menu item.' ),
 			'type'        => 'array',
 			'items'       => array(
 				'type' => 'string',
+			),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => function ( $value ) {
+					return array_map( 'sanitize_html_class', explode( ' ', $value ) );
+				},
 			),
 		);
 
 		$schema['properties']['description'] = array(
 			'description' => __( 'The description of this menu item.' ),
-			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 
 		$schema['properties']['menu_order'] = array(
@@ -716,9 +722,13 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		);
 
 		$schema['properties']['target'] = array(
-			'description' => __( 'The target attribute of the link element for this menu item . The family of objects originally represented, such as "post_type" or "taxonomy."' ),
-			'context'     => array( 'view', 'edit', 'embed' ),
+			'description' => __( 'The target attribute of the link element for this menu item.' ),
 			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'enum'        => array(
+				'_blank',
+				'',
+			),
 		);
 
 		$schema['properties']['type_label'] = array(
@@ -729,20 +739,26 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		);
 
 		$schema['properties']['url'] = array(
-			'description' => __( 'The URL to which this menu item points .' ),
+			'description' => __( 'The URL to which this menu item points.' ),
 			'type'        => 'string',
 			'format'      => 'uri',
 			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'esc_url_raw',
+			),
 		);
 
 		$schema['properties']['xfn'] = array(
-			'description' => __( 'The XFN relationship expressed in the link of this menu item . ' ),
+			'description' => __( 'The XFN relationship expressed in the link of this menu item.' ),
+			'type'        => 'string',
 			'context'     => array( 'view', 'edit', 'embed' ),
-			'type'        => 'array',
-			'items'       => array(
-				'type' => 'string',
+			'arg_options' => array(
+				'sanitize_callback' => function ( $value ) {
+					return implode( ' ', array_map( 'sanitize_html_class', explode( ' ', $value ) ) );
+				},
 			),
 		);
+
 
 		$schema['properties']['_invalid'] = array(
 			'description' => __( '      Whether the menu item represents an object that no longer exists .' ),

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -309,12 +309,15 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 					return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post  ID.' ), array( 'status' => 400 ) );
 				}
 				$prepared_nav_item['menu-item-object'] = get_post_type( $original );
-			} elseif ( 'post_type_archive' === $prepared_nav_item['menu-item-type'] ) { // If post type archive, check if post type exists.
-				$post_type = ( $prepared_nav_item['menu-item-object'] ) ? $prepared_nav_item['menu-item-object'] : false;
-				$original  = get_post_type_object( $post_type );
-				if ( empty( $original ) ) {
-					return new WP_Error( 'rest_post_invalid_type', __( 'Invalid post type.' ), array( 'status' => 400 ) );
-				}
+			}
+		}
+
+		// If post type archive, check if post type exists.
+		if ( 'post_type_archive' === $prepared_nav_item['menu-item-type'] ) {
+			$post_type = ( $prepared_nav_item['menu-item-object'] ) ? $prepared_nav_item['menu-item-object'] : false;
+			$original  = get_post_type_object( $post_type );
+			if ( empty( $original ) ) {
+				return new WP_Error( 'rest_post_invalid_type', __( 'Invalid post type.' ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -279,8 +279,10 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$base     = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		// If menus submitted, then check if 1 menu is given, if more than 1 is given, error out.
 		if ( isset( $request[ $base ] ) && ! empty( $request[ $base ] ) ) {
-			if ( count( $request[ $base ] ) > 1 ) {
-				return new WP_Error( 'rest_single_menu', __( 'Unable to test menu item to multiple menus.' ), array( 'status' => 400 ) );
+			$maxItems  = ( int ) $schema['properties'][ $base ]['maxItems'];
+			$nav_menus = count( $request[ $base ] );
+			if ( $maxItems && $nav_menus > $maxItems ) {
+				return new WP_Error( 'rest_invalid_nav_menu_assignmentss', sprintf( __( 'Unable to menu item to %d menus. Max allowed is %d' ), $nav_menus, $maxItems ), array( 'status' => 400 ) );
 			}
 			$prepared_nav_item['menu-id'] = array_shift( $request[ $base ] );
 		}
@@ -807,6 +809,10 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				),
 				'context'     => array( 'view', 'edit' ),
 			);
+
+			if ( 'nav_menu' === $taxonomy ) {
+				$schema['properties'][ $base ]['maxItems'] = 1;
+			}
 		}
 
 		$schema['properties']['meta'] = $this->meta->get_field_schema();

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -277,7 +277,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$taxonomy = get_taxonomy( 'nav_menu' );
 		$base     = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
-		// If menus submitted, then check if 1 menu is given, if more than 1 is given, error out.
+		// If menus submitted, cast to int.
 		if ( isset( $request[ $base ] ) && ! empty( $request[ $base ] ) ) {
 			$prepared_nav_item['menu-id'] = (int) $request[ $base ];
 		}
@@ -291,7 +291,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
-		// Check if object id existing before saving.
+		// Check if object id exists before saving.
 		if ( ! $prepared_nav_item['menu-item-object'] && $prepared_nav_item['menu-item-object-id'] ) {
 			// If taxonony, check if term exists.
 			if ( 'taxonomy' === $prepared_nav_item['menu-item-type'] ) {

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -279,12 +279,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$base     = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		// If menus submitted, then check if 1 menu is given, if more than 1 is given, error out.
 		if ( isset( $request[ $base ] ) && ! empty( $request[ $base ] ) ) {
-			$maxItems  = ( int ) $schema['properties'][ $base ]['maxItems'];
-			$nav_menus = count( $request[ $base ] );
-			if ( $maxItems && $nav_menus > $maxItems ) {
-				return new WP_Error( 'rest_invalid_nav_menu_assignmentss', sprintf( __( 'Unable to menu item to %d menus. Max allowed is %d' ), $nav_menus, $maxItems ), array( 'status' => 400 ) );
-			}
-			$prepared_nav_item['menu-id'] = array_shift( $request[ $base ] );
+			$prepared_nav_item['menu-id'] = (int) $request[ $base ];
 		}
 
 		// Nav menu title.
@@ -811,7 +806,8 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			);
 
 			if ( 'nav_menu' === $taxonomy ) {
-				$schema['properties'][ $base ]['maxItems'] = 1;
+				$schema['properties'][ $base ]['type'] = 'integer';
+				unset( $schema['properties'][ $base ]['items'] );
 			}
 		}
 

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -53,13 +53,14 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			return new WP_Error( 'rest_post_exists', __( 'Cannot create existing post.' ), array( 'status' => 400 ) );
 		}
 
-		$prepared_nav_item = (array) $this->prepare_item_for_database( $request );
+		$prepared_nav_item = $this->prepare_item_for_database( $request );
 
 		if ( is_wp_error( $prepared_nav_item ) ) {
 			return $prepared_nav_item;
 		}
 		$prepared_nav_item = (array) $prepared_nav_item;
-		$nav_menu_item_id  = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], $prepared_nav_item );
+
+		$nav_menu_item_id = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], $prepared_nav_item );
 
 		if ( is_wp_error( $nav_menu_item_id ) ) {
 			if ( 'db_insert_error' === $nav_menu_item_id->get_error_code() ) {
@@ -204,7 +205,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return stdClass
+	 * @return stdClass|WP_Error
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$menu_item_db_id = $request['id'];
@@ -228,11 +229,8 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				'menu-item-classes'     => implode( ' ', $menu_item_obj->classes ), // stored in the database as array.
 				'menu-item-xfn'         => $menu_item_obj->xfn,
 				'menu-item-status'      => $menu_item_obj->post_status,
+				'menu-id'               => $this->get_menu_id( $menu_item_db_id ),
 			);
-			$menu_ids          = wp_get_post_terms( $menu_item_db_id, 'nav_menu', array( 'fields' => 'ids' ) );
-			if ( $menu_ids && ! is_wp_error( $menu_ids ) ) {
-				$prepared_nav_item['menu-id'] = array_shift( $menu_ids );
-			}
 		} else {
 			$prepared_nav_item = array(
 				'menu-id'               => 0,
@@ -287,6 +285,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
+		// Check if object id existing before saving.
 		if ( ! $prepared_nav_item['menu-item-object'] && $prepared_nav_item['menu-item-object-id'] ) {
 			if ( 'taxonomy' === $prepared_nav_item['menu-item-type'] ) {
 				$original = get_term( (int) $prepared_nav_item['menu-item-object-id'] );
@@ -303,8 +302,89 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
-		$prepared_nav_item['menu-item-classes'] = implode( ' ', array_map( 'sanitize_html_class', $prepared_nav_item['menu-item-classes'] ) );
-		$prepared_nav_item['menu-item-xfn']     = implode( ' ', array_map( 'sanitize_html_class', $prepared_nav_item['menu-item-xfn'] ) );
+		// Check if menu item is type custom, then title and url are required.
+		if ( 'custom' === $prepared_nav_item['menu-item-type'] ) {
+			if ( '' === $prepared_nav_item['menu-item-title'] ) {
+				return new WP_Error( 'rest_title_required', __( 'Title require if menu item of type custom.' ), array( 'status' => 400 ) );
+			}
+			if ( empty( $prepared_nav_item['menu-item-url'] ) ) {
+				return new WP_Error( 'rest_url_required', __( 'URL require if menu item of type custom.' ), array( 'status' => 400 ) );
+			}
+		}
+
+		// If menu if is set, valid position and parent.
+		if ( ! empty( $prepared_nav_item['menu-id'] ) ) {
+			if ( ! is_nav_menu( $prepared_nav_item['menu-id'] ) ) {
+				return new WP_Error( 'invalid_menu_id', __( 'Invalid menu ID.' ), array( 'status' => 400 ) );
+			}
+
+			$menu_items = (array) wp_get_nav_menu_items( $prepared_nav_item['menu-id'], array( 'post_status' => 'publish,draft' ) );
+			if ( 0 === (int) $prepared_nav_item['menu-item-position'] ) {
+				$last_item                               = array_pop( $menu_items );
+				$prepared_nav_item['menu-item-position'] = ( $last_item && isset( $last_item->menu_order ) ) ? 1 + $last_item->menu_order : count( $menu_items );
+			}
+
+			$menu_item_ids = array();
+			foreach ( $menu_items as $menu_item ) {
+				$menu_item_ids[] = $menu_item->ID;
+				if ( $menu_item->ID !== (int) $menu_item_db_id ) {
+					if ( (int) $prepared_nav_item['menu-item-position'] === (int) $menu_item->menu_order ) {
+						return new WP_Error( 'invalid_menu_order', __( 'Invalid menu position.' ), array( 'status' => 400 ) );
+					}
+				}
+			}
+
+			if ( $prepared_nav_item['menu-item-parent-id'] ) {
+				if ( ! is_nav_menu_item( $prepared_nav_item['menu-item-parent-id'] ) ) {
+					return new WP_Error( 'invalid_menu_item_parent', __( 'Invalid menu item parent.' ), array( 'status' => 400 ) );
+				}
+				if ( $menu_item_ids && ! in_array( $prepared_nav_item['menu-item-parent-id'], $menu_item_ids, true ) ) {
+					return new WP_Error( 'invalid_item_parent', __( 'Invalid menu item parent.' ), array( 'status' => 400 ) );
+				}
+			}
+		}
+
+		foreach ( array( 'object_id', 'menu_item_parent', 'nav_menu_term_id' ) as $key ) {
+			// Note we need to allow negative-integer IDs for previewed objects not inserted yet.
+			$prepared_nav_item[ $key ] = intval( $prepared_nav_item[ $key ] );
+		}
+
+		foreach ( array( 'type', 'object', 'target' ) as $key ) {
+			$prepared_nav_item[ $key ] = sanitize_key( $prepared_nav_item[ $key ] );
+		}
+
+		foreach ( array( 'xfn', 'classes' ) as $key ) {
+			$value = $prepared_nav_item[ $key ];
+			if ( ! is_array( $value ) ) {
+				$value = explode( ' ', $value );
+			}
+			$prepared_nav_item[ $key ] = implode( ' ', array_map( 'sanitize_html_class', $value ) );
+		}
+
+		$prepared_nav_item['original_title'] = sanitize_text_field( $prepared_nav_item['original_title'] );
+
+		// Apply the same filters as when calling wp_insert_post().
+
+		/** This filter is documented in wp-includes/post.php */
+		$prepared_nav_item['title'] = wp_unslash( apply_filters( 'title_save_pre', wp_slash( $prepared_nav_item['title'] ) ) );
+
+		/** This filter is documented in wp-includes/post.php */
+		$prepared_nav_item['attr_title'] = wp_unslash( apply_filters( 'excerpt_save_pre', wp_slash( $prepared_nav_item['attr_title'] ) ) );
+
+		/** This filter is documented in wp-includes/post.php */
+		$prepared_nav_item['description'] = wp_unslash( apply_filters( 'content_save_pre', wp_slash( $prepared_nav_item['description'] ) ) );
+
+		if ( '' !== $prepared_nav_item['url'] ) {
+			$prepared_nav_item['url'] = esc_url_raw( $prepared_nav_item['url'] );
+			if ( '' === $prepared_nav_item['url'] ) {
+				return new WP_Error( 'invalid_url', __( 'Invalid URL.' ) ); // Fail sanitization if URL is invalid.
+			}
+		}
+		if ( 'publish' !== $prepared_nav_item['status'] ) {
+			$prepared_nav_item['status'] = 'draft';
+		}
+
+		$prepared_nav_item['_invalid'] = (bool) $prepared_nav_item['_invalid'];
 
 		$prepared_nav_item = (object) $prepared_nav_item;
 
@@ -392,6 +472,10 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			$data['menu_order'] = absint( $menu_item->menu_order ); // Same as post_parent, expose as integer.
 		}
 
+		if ( in_array( 'menu_id', $fields, true ) ) {
+			$data['menu_id'] = $this->get_menu_id( $menu_item->ID );
+		}
+
 		if ( in_array( 'target', $fields, true ) ) {
 			$data['target'] = $menu_item->target;
 		}
@@ -401,7 +485,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		}
 
 		if ( in_array( 'xfn', $fields, true ) ) {
-			$data['xfn'] = (array) $menu_item->xfn;
+			$data['xfn'] = explode( ' ', $menu_item->xfn );
 		}
 
 		if ( in_array( 'meta', $fields, true ) ) {
@@ -480,8 +564,6 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Retrieve Link Description Objects that should be added to the Schema for the posts collection.
 	 *
-	 * @since 4.9.8
-	 *
 	 * @return array
 	 */
 	protected function get_schema_links() {
@@ -543,6 +625,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'Unique identifier for the object.' ),
 			'type'        => 'integer',
 			'default'     => 0,
+			'minimum'     => 0,
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'readonly'    => true,
 		);
@@ -550,6 +633,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['menu_id'] = array(
 			'description' => __( 'Unique identifier for the menu.' ),
 			'type'        => 'integer',
+			'minimum'     => 0,
 			'context'     => array( 'edit' ),
 			'default'     => 0,
 		);
@@ -557,7 +641,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['type_label'] = array(
 			'description' => __( 'Name of type.' ),
 			'type'        => 'string',
-			'context'     => array( 'view', 'embed' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'readonly'    => true,
 		);
 
@@ -565,6 +649,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'Type of menu item' ),
 			'type'        => 'string',
 			'enum'        => array( 'taxonomy', 'post_type', 'post_type_archive', 'custom' ),
+			'default'     => 'custom',
 			'context'     => array( 'view', 'edit', 'embed' ),
 		);
 
@@ -572,7 +657,8 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'A named status for the object.' ),
 			'type'        => 'string',
 			'enum'        => array_keys( get_post_stati( array( 'internal' => false ) ) ),
-			'context'     => array( 'view', 'edit' ),
+			'default'     => 'publish',
+			'context'     => array( 'view', 'edit', 'embed' ),
 		);
 
 		$schema['properties']['link'] = array(
@@ -586,17 +672,20 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['parent'] = array(
 			'description' => __( 'The ID for the parent of the object.' ),
 			'type'        => 'integer',
-			'context'     => array( 'view', 'edit' ),
+			'minimum'     => 0,
+			'default'     => 0,
+			'context'     => array( 'view', 'edit', 'embed' ),
 		);
 
 		$schema['properties']['attr_title'] = array(
 			'description' => __( 'The title attribute of the link element for this menu item .' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'string',
 		);
-		$schema['properties']['classes']    = array(
+
+		$schema['properties']['classes'] = array(
 			'description' => __( 'The array of class attribute values for the link element of this menu item .' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'array',
 			'items'       => array(
 				'type' => 'string',
@@ -605,35 +694,42 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$schema['properties']['description'] = array(
 			'description' => __( 'The description of this menu item.' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'string',
 		);
 
 		$schema['properties']['menu_item_parent'] = array(
 			'description' => __( 'The DB ID of the nav_menu_item that is this item\'s menu parent, if any . 0 otherwise . ' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'integer',
+			'minimum'     => 0,
+			'default'     => 0,
 		);
 
 		$schema['properties']['menu_order'] = array(
 			'description' => __( 'The DB ID of the nav_menu_item that is this item\'s menu parent, if any . 0 otherwise . ' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'integer',
+			'minimum'     => 0,
+			'default'     => 0,
 		);
 		$schema['properties']['object']     = array(
 			'description' => __( 'The type of object originally represented, such as "category," "post", or "attachment."' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'type'        => 'string',
 		);
 
 		$schema['properties']['object_id'] = array(
 			'description' => __( 'The DB ID of the original object this menu item represents, e . g . ID for posts and term_id for categories .' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'integer',
+			'minimum'     => 0,
+			'default'     => 0,
 		);
 
 		$schema['properties']['target'] = array(
 			'description' => __( 'The target attribute of the link element for this menu item . The family of objects originally represented, such as "post_type" or "taxonomy."' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'string',
 		);
 
@@ -648,12 +744,12 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'The URL to which this menu item points .' ),
 			'type'        => 'string',
 			'format'      => 'uri',
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 		);
 
 		$schema['properties']['xfn'] = array(
 			'description' => __( 'The XFN relationship expressed in the link of this menu item . ' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'array',
 			'items'       => array(
 				'type' => 'string',
@@ -662,8 +758,9 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$schema['properties']['_invalid'] = array(
 			'description' => __( '      Whether the menu item represents an object that no longer exists .' ),
-			'context'     => array( 'view', 'edit' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'boolean',
+			'readonly'    => true,
 		);
 
 		$schema['properties']['meta'] = $this->meta->get_field_schema();
@@ -747,5 +844,22 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		}
 
 		return $query_args;
+	}
+
+	/**
+	 * Get menu id of current menu item.
+	 *
+	 * @param int $menu_item_id Menu item id.
+	 *
+	 * @return int
+	 */
+	protected function get_menu_id( $menu_item_id ) {
+		$menu_ids = wp_get_post_terms( $menu_item_id, 'nav_menu', array( 'fields' => 'ids' ) );
+		$menu_id  = 0;
+		if ( $menu_ids && ! is_wp_error( $menu_ids ) ) {
+			$menu_id = array_shift( $menu_ids );
+		}
+
+		return $menu_id;
 	}
 }

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -383,7 +383,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		foreach ( array( 'menu-item-xfn', 'menu-item-classes' ) as $key ) {
 			$value = $prepared_nav_item[ $key ];
 			if ( ! is_array( $value ) ) {
-				$value = explode( ' ', $value );
+				$value = wp_parse_list( $value );
 			}
 			$prepared_nav_item[ $key ] = implode( ' ', array_map( 'sanitize_html_class', $value ) );
 		}
@@ -711,7 +711,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'arg_options' => array(
 				'sanitize_callback' => function ( $value ) {
-					return array_map( 'sanitize_html_class', explode( ' ', $value ) );
+					return array_map( 'sanitize_html_class', wp_parse_list( $value ) );
 				},
 			),
 		);
@@ -779,7 +779,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'arg_options' => array(
 				'sanitize_callback' => function ( $value ) {
-					return array_map( 'sanitize_html_class', explode( ' ', $value ) );
+					return array_map( 'sanitize_html_class', wp_parse_list( $value ) );
 				},
 			),
 		);

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -761,7 +761,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$schema['properties']['type_label'] = array(
 			'description' => __( 'The singular label used to describe this type of menu item.' ),
-			'context'     => array( 'view', 'embed' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'string',
 			'readonly'    => true,
 		);

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -279,7 +279,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		$base     = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		// If menus submitted, cast to int.
 		if ( isset( $request[ $base ] ) && ! empty( $request[ $base ] ) ) {
-			$prepared_nav_item['menu-id'] = (int) $request[ $base ];
+			$prepared_nav_item['menu-id'] = absint( $request[ $base ] );
 		}
 
 		// Nav menu title.
@@ -295,7 +295,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		if ( ! $prepared_nav_item['menu-item-object'] && $prepared_nav_item['menu-item-object-id'] ) {
 			// If taxonony, check if term exists.
 			if ( 'taxonomy' === $prepared_nav_item['menu-item-type'] ) {
-				$original = get_term( (int) $prepared_nav_item['menu-item-object-id'] );
+				$original = get_term( absint( $prepared_nav_item['menu-item-object-id'] ) );
 				if ( empty( $original ) ) {
 					return new WP_Error( 'rest_term_invalid_id', __( 'Invalid term ID.' ), array( 'status' => 400 ) );
 				}
@@ -303,7 +303,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 				// If post, check if post object exists.
 			} elseif ( 'post_type' === $prepared_nav_item['menu-item-type'] ) {
-				$original = get_post( (int) $prepared_nav_item['menu-item-object-id'] );
+				$original = get_post( absint( $prepared_nav_item['menu-item-object-id'] ) );
 				if ( empty( $original ) ) {
 					return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post  ID.' ), array( 'status' => 400 ) );
 				}


### PR DESCRIPTION
Improved validation of saving and displaying fields. Now correct types are checks and fields sanitized.

Much of this code is copied from wp-cli. See [this](https://github.com/wp-cli/entity-command/blob/250ed0da61162819f601fa110251c7e4c5173f27/src/Menu_Item_Command.php#L401-L468).

There is more sanitize found in the customizer [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php#L653-L730).

Also improved all interger values defaults and allowed values. 

This PR validation against the following use cases.

- If menus field submitted, then check if 1 menu is given, if more than 1 is given, error out as a menu item can't be in two menus.
- If item type is set to taxononmy, check if term exists.
- If item type is set to post_type, check if post exists. 
- If item type is set to post_type_archive, check is post type exists.
- If item type is custom, valid that title and url are not empty.
- Check if menu  id is a valid existing menu 
- If menu exists and menu item is 0, set position to last position +1 putting nehew menu items to the end.
- If menu item position is set, check that position isn't already in use.
- If menu item parent is set, check if menu item exists and in same menu.
- Run title, title attr and description through filters. 
- Validate url is valid url.
- Validate post status, publish and draft are only valid post statuses. 

Other changes.
- Add defaults to params
- Add min and max to int fields.
- Add embed to context.
- sanitize_key on string fields.
- Change key for parent to parent over menu parent.
- Populate existing values of menu item on update.

Fixes #38 