### PR TITLE
Add permission check

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -53,7 +53,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			return $post;
 		}
 		if ( $post && ! $this->check_update_permission( $post ) ) {
-			return new WP_Error( 'rest_forbidden_access', __( 'Sorry, you view this menu item, unless you have access to allow edit it. ' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_view', __( 'Sorry, you cannot view this menu item, unless you have access to permission edit it. ' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return parent::get_item_permissions_check( $request );
@@ -71,7 +71,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			if ( 'edit' === $request['context'] ) {
 				return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit posts in this post type.' ), array( 'status' => rest_authorization_required_code() ) );
 			}
-			return new WP_Error( 'rest_forbidden_access', __( 'Sorry, you view these menu items, unless you have access to allow edit them. ' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_view', __( 'Sorry, you cannot view these menu items, unless you have access to permission edit them. ' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -28,7 +28,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 			if ( 'edit' === $request['context'] ) {
 				return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit terms in this taxonomy.' ), array( 'status' => rest_authorization_required_code() ) );
 			}
-			return new WP_Error( 'rest_forbidden_access', __( 'Sorry, you view these menus, unless you have access to allow edit them. ' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_view', __( 'Sorry, you cannot view these menus, unless you have access to permission edit them. ' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -48,7 +48,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 			if ( 'edit' === $request['context'] ) {
 				return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit this term.' ), array( 'status' => rest_authorization_required_code() ) );
 			}
-			return new WP_Error( 'rest_forbidden_access', __( 'Sorry, you view this menu, unless you have access to allow edit it. ' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_view', __( 'Sorry, you cannot view this menu, unless you have access to permission edit it. ' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}

--- a/tests/test-rest-nav-menu-items-controller.php
+++ b/tests/test-rest-nav-menu-items-controller.php
@@ -8,10 +8,17 @@ class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Tes
 
 	protected static $admin_id;
 
+	protected static $subscriber_id;
+
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
 			)
 		);
 	}
@@ -71,5 +78,30 @@ class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Tes
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items/' . $menu_item_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
+	}
+
+	public function test_get_items_wrong_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
+	}
+
+	public function test_get_item_wrong_permission() {
+		$post_id = self::factory()->post->create();
+		$menu_item_id = wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+			)
+		);
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items/' . $menu_item_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
 	}
 }

--- a/tests/test-rest-nav-menu-items-controller.php
+++ b/tests/test-rest-nav-menu-items-controller.php
@@ -52,7 +52,7 @@ class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Tes
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
 
 	public function test_get_item_no_permission() {
@@ -70,6 +70,6 @@ class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Tes
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items/' . $menu_item_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
 }

--- a/tests/test-rest-nav-menu-items-controller.php
+++ b/tests/test-rest-nav-menu-items-controller.php
@@ -1,6 +1,25 @@
 <?php
 
 class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * @var int
+	 */
+	public $menu_id;
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	function setUp() {
+		parent::setUp();
+		$this->menu_id = wp_create_nav_menu( rand_str() );
+	}
 
 	public function test_register_routes() {
 	}
@@ -27,5 +46,30 @@ class WP_Test_REST_Nav_Menu_Items_Controller extends WP_Test_REST_Controller_Tes
 	}
 
 	public function test_get_item_schema() {
+	}
+
+	public function test_get_items_no_permission() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
+	}
+
+	public function test_get_item_no_permission() {
+		$post_id = self::factory()->post->create();
+		$menu_item_id = wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+			)
+		);
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menu-items/' . $menu_item_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
 	}
 }

--- a/tests/test-rest-nav-menus-controller.php
+++ b/tests/test-rest-nav-menus-controller.php
@@ -8,10 +8,17 @@ class WP_Test_REST_Nav_Menus_Controller extends WP_Test_REST_Controller_Testcase
 
 	protected static $admin_id;
 
+	protected static $subscriber_id;
+
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
 			)
 		);
 	}
@@ -85,6 +92,20 @@ class WP_Test_REST_Nav_Menus_Controller extends WP_Test_REST_Controller_Testcase
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menus/' . $this->menu_id  );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
+	}
+
+	public function test_get_items_wrong_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menus' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
+	}
+
+	public function test_get_item_wrong_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/menus/' . $this->menu_id  );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
 	}
 
 }

--- a/tests/test-rest-nav-menus-controller.php
+++ b/tests/test-rest-nav-menus-controller.php
@@ -77,14 +77,14 @@ class WP_Test_REST_Nav_Menus_Controller extends WP_Test_REST_Controller_Testcase
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menus' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
 
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/menus/' . $this->menu_id  );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden_access', $response, 401 );
+		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
 
 }


### PR DESCRIPTION
Add some basic checks (with tests) to check that current user has access to edit a menu / menu item before they can access the object. This means that the menu / menu items will not be public. As a menu might have sensitive data in it, let's make it private for now. 

Fixes #26